### PR TITLE
Start node scripts later

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -6,7 +6,7 @@ UPSTART_TEMPLATE = <<EOD
 description "{{application}} node app"
 author      "capistrano"
 
-start on startup
+start on (filesystem and net-device-up IFACE=lo)
 stop on shutdown
 
 respawn


### PR DESCRIPTION
You should start the node scripts once there is a network interface up and the filesystem is ready.
