### PR TITLE
Set working directory for node process

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -14,7 +14,7 @@ respawn
 respawn limit 99 5
 
 script
-    exec sudo -u {{node_user}} NODE_ENV={{node_env}} {{app_environment}} {{node_binary}} {{current_path}}/{{app_command}} 2>> {{shared_path}}/{{node_env}}.err.log 1>> {{shared_path}}/{{node_env}}.out.log
+    cd {{current_path}} && exec sudo -u {{node_user}} NODE_ENV={{node_env}} {{app_environment}} {{node_binary}} {{current_path}}/{{app_command}} 2>> {{shared_path}}/{{node_env}}.err.log 1>> {{shared_path}}/{{node_env}}.out.log
 end script
 EOD
 


### PR DESCRIPTION
Explicitly set current release as working directory for node process in upstart script. This makes `process.cwd()` return the release directory instead of '/'. 

For example, [snockets](https://github.com/TrevorBurnham/snockets) treats `process.cwd()` as project root, and looks for asset files relative to that.
