### PR TITLE
Change npm install loglevel

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -59,7 +59,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
     task :install_packages do
       run "mkdir -p #{shared_path}/node_modules"
       run "cp #{release_path}/package.json #{shared_path}"
-      run "cd #{shared_path} && npm install #{(node_env == 'production') ? '--production' : ''}"
+      run "cd #{shared_path} && npm install #{(node_env == 'production') ? '--production' : ''} --loglevel warn"
       run "ln -s #{shared_path}/node_modules #{release_path}/node_modules"
     end
 


### PR DESCRIPTION
Better to output only warnings as part of the deploy, otherwise its just too spammy in the cap output.
