### PR TITLE
Fix upstart script for Ubuntu Precise

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -39,7 +39,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
 description "#{application} node app"
 author      "capistrano"
 
-start on (filesystem and net-device-up IFACE=lo)
+start on runlevel [2345]
 stop on shutdown
 
 respawn


### PR DESCRIPTION
Changed to upstart script to use runlevel start because interface condition was not working on Ubuntu Precise.
