### PR TITLE
Support of npm --dev flag.

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -58,7 +58,7 @@ EOD
       run "mkdir -p #{shared_path}/node_modules"
       run "cp #{release_path}/package.json #{shared_path}"
       run "cp #{release_path}/npm-shrinkwrap.json #{shared_path}"
-      run "cd #{shared_path} && npm install #{(node_env == 'production') ? '--production' : ''} --loglevel warn"
+      run "cd #{shared_path} && npm install #{(node_env != 'production') ? '--dev' : ''} --loglevel warn"
       run "ln -s #{shared_path}/node_modules #{release_path}/node_modules"
     end
 


### PR DESCRIPTION
The "--production" flag has deprecated since the last NPM release.
Now we should set the [--dev](https://npmjs.org/doc/json.html#devDependencies) flag when installing packages on non-production environment.
