### PR TITLE
Patch 2

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -65,7 +65,7 @@ EOD
       run "mkdir -p #{shared_path}/node_modules"
       run "cp #{release_path}/package.json #{shared_path}"
       run "cp #{release_path}/npm-shrinkwrap.json #{shared_path}"
-      run "cd #{shared_path} && npm install #{(node_env == 'production') ? '--dev' : ''} --loglevel warn"
+      run "cd #{shared_path} && npm install #{(node_env != 'production') ? '--dev' : ''} --loglevel warn"
       run "ln -s #{shared_path}/node_modules #{release_path}/node_modules"
     end
 


### PR DESCRIPTION
Implemented forever option to replace upstart. Upstart is still available, however forever is a better/easier solution for some people/apps.

There are 4 new config settings as defined starting at line 54.
run_method        set this to 'forever' to use forever
spin_sleep_time miliseconds for spinup time
min_up_time      minimum uptime
max_run            max number of times forever will try to restart
