### PR TITLE
npm install --production

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -70,7 +70,7 @@ EOD
       run "mkdir -p #{shared_path}/node_modules"
       run "cp #{release_path}/package.json #{shared_path}"
       run "cp #{release_path}/npm-shrinkwrap.json #{shared_path}" if remote_file_exists?("#{release_path}/npm-shrinkwrap.json")
-      run "cd #{shared_path} && npm install #{(node_env != 'production') ? '--dev' : ''} --loglevel warn"
+      run "cd #{shared_path} && npm install #{(node_env == 'production') ? '--production' : '--dev' } --loglevel warn"
       run "ln -s #{shared_path}/node_modules #{release_path}/node_modules"
     end
 


### PR DESCRIPTION
Hello,

I noticed that when NODE_ENV is production the gem installs also devDependencies, to avoid that, the script should run: `npm install` with `--production`
