### PR TITLE
removed npm --dev and --production flags

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -70,7 +70,7 @@ EOD
       run "mkdir -p #{shared_path}/node_modules"
       run "cp #{release_path}/package.json #{shared_path}"
       run "cp #{release_path}/npm-shrinkwrap.json #{shared_path}" if remote_file_exists?("#{release_path}/npm-shrinkwrap.json")
-      run "cd #{shared_path} && npm install #{(node_env == 'production') ? '--production' : '--dev' } --loglevel warn"
+      run "cd #{shared_path} && npm install} --loglevel warn"
       run "ln -s #{shared_path}/node_modules #{release_path}/node_modules"
     end
 


### PR DESCRIPTION
I ran into an issue with the --dev flag that would try and install the devDependencies in a never ending loop until it would eat up all the inodes on our server. It seems others have had this problem as well:

https://github.com/isaacs/npm/issues/3043

https://github.com/killdream/claire/issues/26

This SO article and the Github issue above suggested removing the --dev flag as npm install should install them by default now.

http://stackoverflow.com/questions/9268259/how-do-you-install-development-only-npm-modules-for-node-js-package-json

Upon checking the npm docs it appears both the --dev and --production flags have been removed, so I removed them both. Tested it again and our node deployment now goes through smoothly.
