### PR TITLE
Add deploy:cleanup to node deploy workflow

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -30,6 +30,7 @@ Capistrano::Configuration.instance(:must_exist).load do |configuration|
   before "deploy:create_symlink", "node:install_packages"
   after "deploy:update", "node:restart"
   after "deploy:rollback", "node:restart"
+  after "node:restart", "deploy:cleanup"
 
   package_json = MultiJson.load(File.open("package.json").read) rescue {}
 


### PR DESCRIPTION
The gem is not cleaning old releases by itself. Without cleanup, disk can become full because of them.
Task deploy:cleanup uses variable keep_releases, which has 5 as capistrano's default but can customized to any value.
