### PR TITLE
Copy node modules before running install

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -68,7 +68,7 @@ EOD
   namespace :node do
     desc "Check required packages and install if packages are not installed"
     task :install_packages do
-      run "cp -r #{previous_release}/node_modules #{release_path}"
+      run "cp -r #{previous_release}/node_modules #{release_path}" if previous_release
       run "cd #{release_path} && npm install --loglevel warn"
     end
 


### PR DESCRIPTION
This means we get faster deploys while maintaining the ability to get a quick rollback when upgrading node modules.
