### PR TITLE
Fix md5 hash never matching

### DIFF
--- a/lib/capistrano/node-deploy.rb
+++ b/lib/capistrano/node-deploy.rb
@@ -13,7 +13,7 @@ end
 def remote_file_content_same_as?(full_path, content)
   results = []
   invoke_command("md5sum #{full_path} | awk '{ print $1 }'") do |ch, stream, out|
-    results << (out == Digest::MD5.hexdigest(content))
+    results << (out.strip == Digest::MD5.hexdigest(content).strip)
   end
   results == [true]
 end


### PR DESCRIPTION
I was always asked for the password because `md5sum | awk` returns `\r\n` at the end, but `Digest::MD5` does not. This commit strips whitespace from both md5 hashes, so this will no longer be a problem.
